### PR TITLE
close wallet connections methods

### DIFF
--- a/grpc_internal_test.go
+++ b/grpc_internal_test.go
@@ -37,7 +37,7 @@ type ErroringConnectionProvider struct {
 	pb.UnimplementedListerServer
 }
 
-func (c *ErroringConnectionProvider) CloseConnections(endpoints []*Endpoint) {}
+func (c *ErroringConnectionProvider) Close(_ []*Endpoint) {}
 
 // Connection returns a connection and release function.
 func (c *ErroringConnectionProvider) Connection(ctx context.Context, endpoint *Endpoint) (*grpc.ClientConn, func(), error) {
@@ -74,7 +74,7 @@ func (c *BufConnectionProvider) bufDialer(ctx context.Context, in string) (net.C
 	return c.listeners[in].Dial()
 }
 
-func (c *BufConnectionProvider) CloseConnections(endpoints []*Endpoint) {
+func (c *BufConnectionProvider) Close(endpoints []*Endpoint) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	for i := range endpoints {

--- a/parameters.go
+++ b/parameters.go
@@ -24,6 +24,7 @@ type parameters struct {
 	monitor         Metrics
 	timeout         time.Duration
 	name            string
+	connectionName  string
 	credentials     credentials.TransportCredentials
 	endpoints       []*Endpoint
 	poolConnections int32
@@ -79,6 +80,14 @@ func WithEndpoints(endpoints []*Endpoint) Parameter {
 func WithPoolConnections(connections int32) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.poolConnections = connections
+	})
+}
+
+// WithConnectionProviderName sets the name for the connection provider.
+// This is used to distinguish between different connection providers.
+func WithConnectionProviderName(name string) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.connectionName = name
 	})
 }
 

--- a/wallet.go
+++ b/wallet.go
@@ -15,8 +15,6 @@ package dirk
 
 import (
 	"context"
-	"github.com/jackc/puddle/v2"
-	"google.golang.org/grpc"
 	"time"
 
 	"github.com/google/uuid"
@@ -69,10 +67,9 @@ func Open(ctx context.Context,
 	wallet.timeout = parameters.timeout
 	wallet.endpoints = make([]*Endpoint, len(parameters.endpoints))
 	wallet.connectionProvider = &PuddleConnectionProvider{
-		name:            parameters.name,
+		name:            parameters.connectionName,
 		poolConnections: parameters.poolConnections,
 		credentials:     parameters.credentials.Clone(),
-		connectionPools: make(map[string]*puddle.Pool[*grpc.ClientConn]),
 	}
 	for i := range parameters.endpoints {
 		wallet.endpoints[i] = &Endpoint{
@@ -93,7 +90,6 @@ func OpenWallet(_ context.Context, name string, credentials credentials.Transpor
 	wallet.connectionProvider = &PuddleConnectionProvider{
 		poolConnections: 32,
 		credentials:     credentials.Clone(),
-		connectionPools: make(map[string]*puddle.Pool[*grpc.ClientConn]),
 	}
 	for i := range endpoints {
 		wallet.endpoints[i] = &Endpoint{
@@ -190,9 +186,9 @@ func (w *wallet) CreateDistributedAccount(ctx context.Context, name string, part
 	return w.GenerateDistributedAccount(ctx, name, participants, signingThreshold, passphrase)
 }
 
-// CloseConnections closes connections for wallet.
-func (w *wallet) CloseConnections() {
-	w.connectionProvider.CloseConnections(w.endpoints)
+// Close closes connections for wallet.
+func (w *wallet) Close() {
+	w.connectionProvider.Close(w.endpoints)
 }
 
 // SetConnectionProvider sets a connection provider for the wallet.


### PR DESCRIPTION
For cases when connection to dirk go through short-living certifications, current implementation not allow re-load changed certificates because of in-memory pool of grpc connections. Even if certificate was re-loaded and wallet re-created, all connections trigger error because of cached connections

to avoid this added modification - move connection map from global to package to build in to struct `PuddleConnectionProvider`

to prevent of leak memory for unused old connections was added function `CloseConnections`