### PR TITLE
Fix data race on account endpoint field

### DIFF
--- a/account.go
+++ b/account.go
@@ -69,6 +69,21 @@ func (a *account) Wallet() e2wtypes.Wallet {
 	return a.wallet
 }
 
+// SetEndpoint sets the endpoint for the account.
+func (a *account) SetEndpoint(endpoint *Endpoint) {
+	a.mutex.Lock()
+	a.endpoint = endpoint
+	a.mutex.Unlock()
+}
+
+// Endpoint returns the endpoint for the account.
+func (a *account) Endpoint() *Endpoint {
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+
+	return a.endpoint
+}
+
 // Lock locks the account.  A locked account cannot sign data.
 func (a *account) Lock(ctx context.Context) error {
 	err := a.wallet.LockAccount(ctx, a.name)

--- a/distributedaccount.go
+++ b/distributedaccount.go
@@ -102,6 +102,21 @@ func (a *distributedAccount) Wallet() e2wtypes.Wallet {
 	return a.wallet
 }
 
+// SetEndpoint sets the endpoint for the account.
+func (a *distributedAccount) SetEndpoint(endpoint *Endpoint) {
+	a.mutex.Lock()
+	a.endpoint = endpoint
+	a.mutex.Unlock()
+}
+
+// Endpoint returns the endpoint for the account.
+func (a *distributedAccount) Endpoint() *Endpoint {
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+
+	return a.endpoint
+}
+
 // Lock locks the account.  A locked account cannot sign data.
 func (a *distributedAccount) Lock(ctx context.Context) error {
 	err := a.wallet.LockAccount(ctx, a.name)

--- a/grpc.go
+++ b/grpc.go
@@ -398,7 +398,7 @@ func (a *account) SignGRPC(ctx context.Context,
 
 	// Use the endpoint set in the account if available,
 	// otherwise use the first endpoint from the wallet (for backwards compatibility).
-	endpoint := a.endpoint
+	endpoint := a.Endpoint()
 	if endpoint == nil {
 		endpoint = a.wallet.endpoints[0]
 	}
@@ -525,7 +525,7 @@ func (a *account) SignMultiGRPC(ctx context.Context,
 
 	// Use the endpoint set in the account if available,
 	// otherwise use the first endpoint from the wallet (for backwards compatibility).
-	endpoint := a.endpoint
+	endpoint := a.Endpoint()
 	if endpoint == nil {
 		endpoint = a.wallet.endpoints[0]
 	}
@@ -655,7 +655,7 @@ func (a *account) SignBeaconProposalGRPC(ctx context.Context,
 
 	// Use the endpoint set in the account if available,
 	// otherwise use the first endpoint from the wallet (for backwards compatibility).
-	endpoint := a.endpoint
+	endpoint := a.Endpoint()
 	if endpoint == nil {
 		endpoint = a.wallet.endpoints[0]
 	}
@@ -782,7 +782,7 @@ func (a *account) SignBeaconAttestationGRPC(ctx context.Context,
 
 	// Use the endpoint set in the account if available,
 	// otherwise use the first endpoint from the wallet (for backwards compatibility).
-	endpoint := a.endpoint
+	endpoint := a.Endpoint()
 	if endpoint == nil {
 		endpoint = a.wallet.endpoints[0]
 	}
@@ -931,7 +931,7 @@ func (a *account) SignBeaconAttestationsGRPC(ctx context.Context,
 
 	// Use the endpoint set in the account if available,
 	// otherwise use the first endpoint from the wallet (for backwards compatibility).
-	endpoint := a.endpoint
+	endpoint := a.Endpoint()
 	if endpoint == nil {
 		endpoint = a.wallet.endpoints[0]
 	}
@@ -1927,7 +1927,7 @@ func (w *wallet) obtainAccount(respAccount *pb.Account, endpoint *Endpoint) (
 	if exists {
 		// Ensure endpoint is set even for cached accounts
 		if acc, ok := cachedAccount.(*account); ok {
-			acc.endpoint = endpoint
+			acc.SetEndpoint(endpoint)
 		}
 
 		return cachedAccount, nil
@@ -1955,7 +1955,7 @@ func (w *wallet) obtainAccount(respAccount *pb.Account, endpoint *Endpoint) (
 	}
 
 	acc := newAccount(w, uuid, name, pubKey, 1)
-	acc.endpoint = endpoint
+	acc.SetEndpoint(endpoint)
 
 	w.accountMapMu.Lock()
 	w.accountMap[key] = acc
@@ -1977,7 +1977,7 @@ func (w *wallet) obtainDistributedAccount(respAccount *pb.DistributedAccount, en
 	if exists {
 		// Ensure endpoint is set even for cached accounts
 		if acc, ok := cachedAccount.(*distributedAccount); ok {
-			acc.endpoint = endpoint
+			acc.SetEndpoint(endpoint)
 		}
 
 		return cachedAccount, nil
@@ -2018,7 +2018,7 @@ func (w *wallet) obtainDistributedAccount(respAccount *pb.DistributedAccount, en
 	}
 
 	acc := newDistributedAccount(w, uuid, name, pubKey, compositePubKey, respAccount.GetSigningThreshold(), participants, 1)
-	acc.endpoint = endpoint
+	acc.SetEndpoint(endpoint)
 
 	w.accountMapMu.Lock()
 	w.accountMap[key] = acc

--- a/grpc_internal_test.go
+++ b/grpc_internal_test.go
@@ -368,7 +368,7 @@ func TestAccountEndpointConcurrentAccess(t *testing.T) {
 		Uuid:      _byte("0x00000000000000000000000000000001"),
 	}
 
-	// Pre-populate the cache so all goroutines hit the cached path (line 1930).
+	// Pre-populate the cache so all goroutines hit the cached path.
 	_, err := w.obtainAccount(respAccount, &Endpoint{host: "seed", port: 0})
 	require.NoError(t, err)
 
@@ -408,7 +408,7 @@ func TestDistributedAccountEndpointConcurrentAccess(t *testing.T) {
 		},
 	}
 
-	// Pre-populate the cache so all goroutines hit the cached path (line 1980).
+	// Pre-populate the cache so all goroutines hit the cached path.
 	_, err := w.obtainDistributedAccount(respAccount, &Endpoint{host: "seed", port: 0})
 	require.NoError(t, err)
 

--- a/grpc_internal_test.go
+++ b/grpc_internal_test.go
@@ -283,7 +283,7 @@ func TestAccountUsesCorrectEndpointForSigning(t *testing.T) {
 	for _, acct := range accounts {
 		var accountEndpoint *Endpoint
 		if acc, ok := acct.(*account); ok {
-			accountEndpoint = acc.endpoint
+			accountEndpoint = acc.Endpoint()
 		}
 
 		require.NotNil(t, accountEndpoint, "Account should have an endpoint assigned")
@@ -350,6 +350,80 @@ func TestAccountUsesCorrectEndpointForSigning(t *testing.T) {
 	// This demonstrates that endpoint reassignment works correctly and accounts use their assigned endpoint for signing
 	t.Logf("Shared account 'Account Endpoint1' was assigned to endpoint: %s:%d",
 		endpointByAccount["Account Endpoint1"].host, endpointByAccount["Account Endpoint1"].port)
+}
+
+// TestAccountEndpointConcurrentAccess verifies that concurrent calls to
+// obtainAccount for the same cached account do not race on the endpoint field.
+func TestAccountEndpointConcurrentAccess(t *testing.T) {
+	require.NoError(t, e2types.InitBLS())
+
+	w := &wallet{
+		endpoints:  []*Endpoint{{host: "localhost", port: 12345}},
+		accountMap: make(map[[48]byte]e2wtypes.Account),
+	}
+
+	respAccount := &pb.Account{
+		Name:      "Shared Account",
+		PublicKey: _byte("0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c"),
+		Uuid:      _byte("0x00000000000000000000000000000001"),
+	}
+
+	// Pre-populate the cache so all goroutines hit the cached path (line 1930).
+	_, err := w.obtainAccount(respAccount, &Endpoint{host: "seed", port: 0})
+	require.NoError(t, err)
+
+	// Concurrently call obtainAccount with different endpoints on the same cached account.
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ep := &Endpoint{host: "host", port: uint32(i)}
+			_, err := w.obtainAccount(respAccount, ep)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestDistributedAccountEndpointConcurrentAccess verifies that concurrent calls to
+// obtainDistributedAccount for the same cached account do not race on the endpoint field.
+func TestDistributedAccountEndpointConcurrentAccess(t *testing.T) {
+	require.NoError(t, e2types.InitBLS())
+
+	w := &wallet{
+		endpoints:  []*Endpoint{{host: "localhost", port: 12345}},
+		accountMap: make(map[[48]byte]e2wtypes.Account),
+	}
+
+	respAccount := &pb.DistributedAccount{
+		Name:               "Shared Distributed",
+		PublicKey:          _byte("0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c"),
+		CompositePublicKey: _byte("0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b"),
+		SigningThreshold:   2,
+		Uuid:               _byte("0x00000000000000000000000000000010"),
+		Participants: []*pb.Endpoint{
+			{Id: 1, Name: "host1", Port: 12345},
+			{Id: 2, Name: "host2", Port: 12346},
+		},
+	}
+
+	// Pre-populate the cache so all goroutines hit the cached path (line 1980).
+	_, err := w.obtainDistributedAccount(respAccount, &Endpoint{host: "seed", port: 0})
+	require.NoError(t, err)
+
+	// Concurrently call obtainDistributedAccount with different endpoints on the same cached account.
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ep := &Endpoint{host: "host", port: uint32(i)}
+			_, err := w.obtainDistributedAccount(respAccount, ep)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
 }
 
 // Disabled because it results in a link back to Dirk repository for

--- a/mock/listerserver.go
+++ b/mock/listerserver.go
@@ -327,7 +327,8 @@ func (s *MockListerServerOverlappingAccounts) ListAccounts(_ context.Context, in
 type CustomListerServer struct {
 	pb.UnimplementedListerServer
 
-	Accounts []*pb.Account
+	Accounts            []*pb.Account
+	DistributedAccounts []*pb.DistributedAccount
 }
 
 func (s *CustomListerServer) ListAccounts(_ context.Context, in *pb.ListAccountsRequest) (*pb.ListAccountsResponse, error) {
@@ -352,9 +353,29 @@ func (s *CustomListerServer) ListAccounts(_ context.Context, in *pb.ListAccounts
 		}
 	}
 
+	var filteredDistributedAccounts []*pb.DistributedAccount
+
+	for _, account := range s.DistributedAccounts {
+		if len(in.GetPaths()) == 0 {
+			filteredDistributedAccounts = append(filteredDistributedAccounts, account)
+		} else {
+			for _, path := range in.GetPaths() {
+				if !strings.Contains(path, "/") {
+					filteredDistributedAccounts = append(filteredDistributedAccounts, account)
+					break
+				}
+
+				if strings.HasSuffix(path, fmt.Sprintf("/%s", account.GetName())) {
+					filteredDistributedAccounts = append(filteredDistributedAccounts, account)
+					break
+				}
+			}
+		}
+	}
+
 	return &pb.ListAccountsResponse{
 		State:               pb.ResponseState_SUCCEEDED,
 		Accounts:            filteredAccounts,
-		DistributedAccounts: nil,
+		DistributedAccounts: filteredDistributedAccounts,
 	}, nil
 }


### PR DESCRIPTION
## Changes
- Multiple goroutines in `List()` can concurrently call `obtainAccount`/`obtainDistributedAccount` for the same cached account, racing to write the `endpoint` field without synchronization
- Protect the `endpoint` field with the existing account `mutex` via `SetEndpoint`/`Endpoint` accessors
- Add race-detector tests that confirm the fix (previously flagged at `grpc.go:1930` and `grpc.go:1980`)